### PR TITLE
fix: No need for complete OpenCV

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ addict
 yapf
 timm
 numpy
-opencv-python
+opencv-python-headless
 supervision==0.6.0
 pycocotools


### PR DESCRIPTION
I believe there's no need to import the whole OpenCV package for the usage here. 

This should reduce package size and prevent conflicts with other packages that use headless OpenCV.

Please, let me know if I should change the version number or if this is automatically handled.

Thank you!